### PR TITLE
re #69 adding in switch not to delete eclaim source

### DIFF
--- a/django_app_server_db_server/deployment/group_vars/all
+++ b/django_app_server_db_server/deployment/group_vars/all
@@ -1,2 +1,3 @@
 deployment_url: "{{ lookup('env', 'DEPLOYMENT_URL') }}"
 eclaim_branch: "{{ lookup('env', 'ECLAIM_BRANCH') }}"
+maintain_source: "False"

--- a/django_app_server_db_server/deployment/roles/app_server/tasks/eclaim.yml
+++ b/django_app_server_db_server/deployment/roles/app_server/tasks/eclaim.yml
@@ -29,6 +29,7 @@
 
 - name: Rub out old eclaim folder
   file: path=/opt/eclaim state=absent
+  when: maintain_source == "False"
 
 - name: Make sure pillow installed for eclaim
   # conda: name=pillow state=latest executable=/opt/miniconda2/bin/conda
@@ -38,6 +39,7 @@
 
 - name: Checkout eclaim source code
   hg: repo={{ deployment_url }} dest=/opt/eclaim force=yes version=default
+  when: maintain_source == "False"
 
 - name: Downgrade pip to 6.1.1
   shell: pip install pip==6.1.1

--- a/django_app_server_db_server/deployment/roles/app_server/tasks/eclaim_revamp.yml
+++ b/django_app_server_db_server/deployment/roles/app_server/tasks/eclaim_revamp.yml
@@ -2,6 +2,7 @@
 
 - name: Rub out old eclaim_revamp folder
   file: path=/opt/eclaim_revamp state=absent
+  when: maintain_source == "False"
 
 - name: Setup miniconda path
   lineinfile: dest=/root/.{{ item }} regexp="miniconda2" line="PATH=/opt/miniconda2/bin:$PATH"
@@ -17,6 +18,7 @@
 
 - name: Checkout eclaim_revamp source code
   git: repo={{ deployment_url }} dest=/opt/eclaim_revamp force=yes version={{ eclaim_branch }} accept_hostkey=yes
+  when: maintain_source == "False"
 
 - name: Install uwsgi.ini file
   template: src=templates/common.py dest={{ django_app_home }}/config/modules/common.py mode=0644


### PR DESCRIPTION
Changes to add one switch `maintain_source` as an argument to ansible. After adding this, running it will be something like: 

`ansible-playbook -i .....blabla -e "maintain_source=True"`

The default argument is `False` so running it without the argument will fall back to replacing the eclaim source folder. 