### PR TITLE
Left out one requirement for app_server re #94

### DIFF
--- a/django_app_server_db_server/deployment/roles/app_server/tasks/RedHat.yml
+++ b/django_app_server_db_server/deployment/roles/app_server/tasks/RedHat.yml
@@ -6,6 +6,7 @@
     - epel-release
     - gcc
     - glibc-common
+    - postgresql-devel
     - uwsgi
 
 - name: Install environment to avoid problems with environment


### PR DESCRIPTION
Left out `postgresql-devel` for `appserver` which is needed to install `psycopg`.